### PR TITLE
Need the admin user to be active

### DIFF
--- a/Resources/data/fixtures/doctrine/generic/data.php
+++ b/Resources/data/fixtures/doctrine/generic/data.php
@@ -31,6 +31,7 @@ $admin->setUsername('admin');
 $admin->setEmail('admin@site.org');
 $admin->setPassword('admin');
 $admin->setIsSuperAdmin(true);
+$admin->setIsActive(true);
 
 $nbUsers = 5;
 for ($it = 1; $it <= $nbUsers; $it++) {


### PR DESCRIPTION
With proper login checks, the admin user can't login now. The bundle should probaby also be updated to include a check on isActive when logging in. 
