### PR TITLE
added translation API calls everywhere, fixed theme support

### DIFF
--- a/Form/ChangePasswordForm.php
+++ b/Form/ChangePasswordForm.php
@@ -21,7 +21,7 @@ class ChangePasswordForm extends Form
      */
     public function __construct($name, $data, ValidatorInterface $validator, array $options = array())
     {
-        $this->addOption('theme', array());
+        $this->addOption('theme');
 
         parent::__construct($name, $data, $validator, $options);
     }

--- a/Form/GroupForm.php
+++ b/Form/GroupForm.php
@@ -20,7 +20,7 @@ class GroupForm extends Form
      */
     public function __construct($name, $data, ValidatorInterface $validator, array $options = array())
     {
-        $this->addOption('theme', array());
+        $this->addOption('theme');
 
         parent::__construct($name, $data, $validator, $options);
     }

--- a/Form/PermissionForm.php
+++ b/Form/PermissionForm.php
@@ -20,7 +20,7 @@ class PermissionForm extends Form
      */
     public function __construct($name, $data, ValidatorInterface $validator, array $options = array())
     {
-        $this->addOption('theme', array());
+        $this->addOption('theme');
 
         parent::__construct($name, $data, $validator, $options);
     }

--- a/Form/SessionForm.php
+++ b/Form/SessionForm.php
@@ -21,7 +21,7 @@ class SessionForm extends Form
      */
     public function __construct($name, $data, ValidatorInterface $validator, array $options = array())
     {
-        $this->addOption('theme', array());
+        $this->addOption('theme');
 
         parent::__construct($name, $data, $validator, $options);
     }

--- a/Form/UserForm.php
+++ b/Form/UserForm.php
@@ -21,7 +21,7 @@ class UserForm extends Form
      */
     public function __construct($title, $data, ValidatorInterface $validator, array $options = array())
     {
-        $this->addOption('theme', array());
+        $this->addOption('theme');
         $this->addOption('categoryRepository');
         $this->addOption('columnRepository');
         $this->addOption('showPublishedAt');

--- a/Resources/config/controller.xml
+++ b/Resources/config/controller.xml
@@ -7,7 +7,7 @@
     <parameters>
         <parameter key="doctrine_user.session_create.success_route">doctrine_user_session_success</parameter>
         <parameter key="doctrine_user.template.renderer">twig</parameter>
-        <parameter type="collection" key="doctrine_user.template.theme"></parameter>
+        <parameter key="doctrine_user.template.theme">TwigBundle::form.twig</parameter>
     </parameters>
 
 </container>

--- a/Resources/views/Group/edit_content.twig
+++ b/Resources/views/Group/edit_content.twig
@@ -1,3 +1,4 @@
+{% form_theme form form.getTheme() %}
 <form action="{% route 'doctrine_user_group_update' %}" {{ form|render_enctype }} method="POST" class="doctrine_user_group_edit">
     <ul>
         {% for field in form.getVisibleFieldsRecursively() %}

--- a/Resources/views/Group/edit_content.twig
+++ b/Resources/views/Group/edit_content.twig
@@ -1,4 +1,4 @@
-{% form_theme form form.getTheme() %}
+{% form_theme form form.getOption('theme') %}
 <form action="{% route 'doctrine_user_group_update' %}" {{ form|render_enctype }} method="POST" class="doctrine_user_group_edit">
     <ul>
         {% for field in form.getVisibleFieldsRecursively() %}

--- a/Resources/views/Group/new_content.twig
+++ b/Resources/views/Group/new_content.twig
@@ -1,3 +1,4 @@
+{% form_theme form form.getTheme() %}
 <form action="{% route 'doctrine_user_group_create' %}" {{ form|render_enctype }} method="POST" class="doctrine_user_group_new">
     <ul>
         {% for field in form.getVisibleFieldsRecursively() %}

--- a/Resources/views/Group/new_content.twig
+++ b/Resources/views/Group/new_content.twig
@@ -1,4 +1,4 @@
-{% form_theme form form.getTheme() %}
+{% form_theme form form.getOption('theme') %}
 <form action="{% route 'doctrine_user_group_create' %}" {{ form|render_enctype }} method="POST" class="doctrine_user_group_new">
     <ul>
         {% for field in form.getVisibleFieldsRecursively() %}

--- a/Resources/views/Group/show_content.twig
+++ b/Resources/views/Group/show_content.twig
@@ -14,11 +14,11 @@
     <table>
         <tbody>
             <tr>
-                <th>Name</th>
+                <th>{% trans "Name" from DoctrineUserBundle %}</th>
                 <td>{{ group.getName() }}</td>
             </tr>
             <tr>
-                <th>Description</th>
+                <th>{% trans "Description" from DoctrineUserBundle %}</th>
                 <td>{{ group.getDescription()|nlbr }}</td>
             </tr>
         </tbody>

--- a/Resources/views/Permission/edit_content.twig
+++ b/Resources/views/Permission/edit_content.twig
@@ -1,3 +1,4 @@
+ {% form_theme form form.getTheme() %}
  <form action="{% route 'doctrine_user_permission_update' %}" {{ form|render_enctype }} method="POST" class="doctrine_user_permission_edit">
      <ul>
          {% for field in form.getVisibleFieldsRecursively() %}

--- a/Resources/views/Permission/edit_content.twig
+++ b/Resources/views/Permission/edit_content.twig
@@ -1,12 +1,12 @@
- {% form_theme form form.getTheme() %}
- <form action="{% route 'doctrine_user_permission_update' %}" {{ form|render_enctype }} method="POST" class="doctrine_user_permission_edit">
-     <ul>
-         {% for field in form.getVisibleFieldsRecursively() %}
-             {{ field|render }}
-         {% endfor %}
-         <li>
-             <input type="submit" value="{% trans 'Update permission' from DoctrineUserBundle %}" />
-         </li>
-     </ul>
-     {{ form|render_hidden }}
- </form>
+{% form_theme form form.getOption('theme') %}
+<form action="{% route 'doctrine_user_permission_update' %}" {{ form|render_enctype }} method="POST" class="doctrine_user_permission_edit">
+    <ul>
+        {% for field in form.getVisibleFieldsRecursively() %}
+            {{ field|render }}
+        {% endfor %}
+        <li>
+            <input type="submit" value="{% trans 'Update permission' from DoctrineUserBundle %}" />
+        </li>
+    </ul>
+    {{ form|render_hidden }}
+</form>

--- a/Resources/views/Permission/new_content.twig
+++ b/Resources/views/Permission/new_content.twig
@@ -1,12 +1,12 @@
- {% form_theme form form.getTheme() %}
- <form action="{% route 'doctrine_user_permission_create' %}" {{ form|render_enctype }} method="POST" class="doctrine_user_permission_new">
-     <ul>
-         {% for field in form.getVisibleFieldsRecursively() %}
-             {{ field|render }}
-         {% endfor %}
-         <li>
-             <input type="submit" value="{% trans 'Create permission' from 'DoctrineUserBundle' %}" />
-         </li>
-     </ul>
-     {{ form|render_hidden }}
- </form>
+{% form_theme form form.getOption('theme') %}
+<form action="{% route 'doctrine_user_permission_create' %}" {{ form|render_enctype }} method="POST" class="doctrine_user_permission_new">
+    <ul>
+        {% for field in form.getVisibleFieldsRecursively() %}
+            {{ field|render }}
+        {% endfor %}
+        <li>
+            <input type="submit" value="{% trans 'Create permission' from 'DoctrineUserBundle' %}" />
+        </li>
+    </ul>
+    {{ form|render_hidden }}
+</form>

--- a/Resources/views/Permission/new_content.twig
+++ b/Resources/views/Permission/new_content.twig
@@ -1,3 +1,4 @@
+ {% form_theme form form.getTheme() %}
  <form action="{% route 'doctrine_user_permission_create' %}" {{ form|render_enctype }} method="POST" class="doctrine_user_permission_new">
      <ul>
          {% for field in form.getVisibleFieldsRecursively() %}

--- a/Resources/views/Permission/show_content.twig
+++ b/Resources/views/Permission/show_content.twig
@@ -14,11 +14,11 @@
     <table>
         <tbody>
             <tr>
-                <th>Name</th>
+                <th>{% trans "Name" from DoctrineUserBundle %}</th>
                 <td>{{ permission.getName() }}</td>
             </tr>
             <tr>
-                <th>Description</th>
+                <th>{% trans "Description" from DoctrineUserBundle %}</th>
                 <td>{{ permission.getDescription()|nlbr }}</td>
             </tr>
         </tbody>

--- a/Resources/views/Session/new_content.twig
+++ b/Resources/views/Session/new_content.twig
@@ -4,7 +4,7 @@
 </div>
 {% endif %}
 
-{% form_theme form form.getTheme() %}
+{% form_theme form form.getOption('theme') %}
 <form action="{% route 'doctrine_user_session_create' %}" {{ form|render_enctype }} method="POST" class="doctrine_user_session_new">
     <ul>
         {% for field in form.getVisibleFieldsRecursively() %}

--- a/Resources/views/Session/new_content.twig
+++ b/Resources/views/Session/new_content.twig
@@ -4,6 +4,7 @@
 </div>
 {% endif %}
 
+{% form_theme form form.getTheme() %}
 <form action="{% route 'doctrine_user_session_create' %}" {{ form|render_enctype }} method="POST" class="doctrine_user_session_new">
     <ul>
         {% for field in form.getVisibleFieldsRecursively() %}

--- a/Resources/views/Session/success_content.twig
+++ b/Resources/views/Session/success_content.twig
@@ -1,5 +1,5 @@
 <div class="doctrine_user_session_create_success">
-    <h1>Hello, {{ _view.auth.getUser()->getUsername() }}!</h1>
+    <h1>Hello, {{ _view.auth.getUser().getUsername() }}!</h1>
     You have been logged in successfully.
     <a href="{% route 'doctrine_user_session_delete' %}">Log out</a>
 </div>

--- a/Resources/views/Session/success_content.twig
+++ b/Resources/views/Session/success_content.twig
@@ -1,5 +1,5 @@
 <div class="doctrine_user_session_create_success">
-    <h1>Hello, {{ _view.auth.getUser().getUsername() }}!</h1>
-    You have been logged in successfully.
-    <a href="{% route 'doctrine_user_session_delete' %}">Log out</a>
+    <h1>{% trans "Hello, {{ username }}!" from DoctrineUserBundle %}</h1>
+    {% trans "You have been logged in successfully." from DoctrineUserBundle %}
+    <a href="{% route 'doctrine_user_session_delete' %}">{% trans "Log out" from DoctrineUserBundle %}</a>
 </div>

--- a/Resources/views/User/checkConfirmationEmail.twig
+++ b/Resources/views/User/checkConfirmationEmail.twig
@@ -1,1 +1,2 @@
-An email has been sent to {{ user.getEmail() }}. It contains an activation link you must click to activate your account.
+{% set email = user.getEmail() %}
+{% trans "An email has been sent to {{ email }}. It contains an activation link you must click to activate your account." from DoctrineUserBundle %}

--- a/Resources/views/User/confirmationEmail.twig
+++ b/Resources/views/User/confirmationEmail.twig
@@ -1,8 +1,10 @@
-Welcome, dear {{ user.getUsername() }}
-Hello {{ user.getUsername() }}!
+{% set username = user.getUsername() %}
+{% trans %}
+    Hello {{ username }}!
 
-To finish validating your account - please visit {{ confirmationUrl }}
+    To finish validating your account - please visit {{ confirmationUrl }}
 
-Regards,
+    Regards,
 
-the Team.
+    the Team.
+{% endtrans %}

--- a/Resources/views/User/confirmed.twig
+++ b/Resources/views/User/confirmed.twig
@@ -1,1 +1,2 @@
-Congrats {{ _view.auth.getUser().getUsername() }}, your account is now confirmed.
+{% set username = _view.auth.getUser().getUsername() %}
+{% trans "Congrats {{ username }}, your account is now confirmed." from DoctrineUserBundle %}

--- a/Resources/views/User/edit_content.twig
+++ b/Resources/views/User/edit_content.twig
@@ -1,4 +1,4 @@
-{% form_theme form form.getTheme() %}
+{% form_theme form form.getOption('theme') %}
 <form action="{% route 'doctrine_user_user_update' %}" {{ form|render_enctype }} method="POST" class="doctrine_user_user_edit">
     <ul>
         {% for field in form.getVisibleFieldsRecursively() %}

--- a/Resources/views/User/edit_content.twig
+++ b/Resources/views/User/edit_content.twig
@@ -1,3 +1,4 @@
+{% form_theme form form.getTheme() %}
 <form action="{% route 'doctrine_user_user_update' %}" {{ form|render_enctype }} method="POST" class="doctrine_user_user_edit">
     <ul>
         {% for field in form.getVisibleFieldsRecursively() %}

--- a/Resources/views/User/show_content.twig
+++ b/Resources/views/User/show_content.twig
@@ -11,6 +11,6 @@
 {% endif %}
 
 <div class="doctrine_user_user_show">
-    <p>Username: {{ user.getUsername() }}</p>
-    <p>Email: {{ user.getEmail() }}</p>
+    <p>{% trans "Username" from DoctrineUserBundle %}: {{ user.getUsername() }}</p>
+    <p>{% trans "Email" from DoctrineUserBundle %}: {{ user.getEmail() }}</p>
 </div>


### PR DESCRIPTION
note that currently the default theme is set to Symfony's default theme, which is a bit annoying since if you override the default you also need to set it in the DoctrineUserBundle config. Jordi will look into making it possible so that setting an empty theme has no effect, so that we can set the default theme parameter to an empty string.
