### PR TITLE
Algorithm fix

### DIFF
--- a/DependencyInjection/DoctrineUserExtension.php
+++ b/DependencyInjection/DoctrineUserExtension.php
@@ -31,6 +31,13 @@ class DoctrineUserExtension extends Extension
             throw new \InvalidArgumentException('You must define your user model class');
         }
 
+        // TODO: this needs to be removed eventually once we figure out how to be able to determine the encoder
+        if (!isset($config['password_encoder'])) {
+            throw new \InvalidArgumentException('You must define your password_encoder');
+        }
+
+        $container->setParameter('doctrine_user.password_encoder', $config['password_encoder']);
+
         $namespaces = array(
             '' => array(
                 'session_create_success_route' => 'doctrine_user.session_create.success_route',

--- a/Model/User.php
+++ b/Model/User.php
@@ -12,7 +12,6 @@ namespace Bundle\DoctrineUserBundle\Model;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Component\Security\User\AdvancedAccountInterface;
-use Symfony\Component\Security\Encoder\MessageDigestPasswordEncoder;
 
 /**
  * Storage agnostic user object
@@ -73,6 +72,11 @@ abstract class User implements AdvancedAccountInterface
      * @var string
      */
     protected $passwordHash;
+
+    /**
+     * @var string
+     */
+    protected $algorithm;
 
     /**
      * @var string
@@ -257,12 +261,22 @@ abstract class User implements AdvancedAccountInterface
     }
 
     /**
-     * Hashed password
+     * Return the algorithm used to hash the password
+     *
+     * @return string the algorithm
+     **/
+    public function getAlgorithm()
+    {
+        return $this->algorithm;
+    }
+
+    /**
+     * Get password
      * @return string
      */
     public function getPassword()
     {
-        return $this->passwordHash;
+        return $this->password;
     }
 
     /**
@@ -281,7 +295,6 @@ abstract class User implements AdvancedAccountInterface
     public function setPassword($password)
     {
         $this->password = $password;
-        $this->hashPassword();
     }
 
     /**
@@ -367,18 +380,14 @@ abstract class User implements AdvancedAccountInterface
     }
 
     /**
-     * Encode the user password
-     * @return null
+     * Encode the user hashed password
+     * @param string $hashPassword
+     * @param string $algorithm
      */
-    protected function hashPassword()
+    public function setPasswordHash($hashPassword, $algorithm)
     {
-        // TODO: the Symfony2 security layer should take care of hashing the password
-        if (empty($this->password)) {
-            $this->hashPassword = null;
-        } else {
-            $encoder = new MessageDigestPasswordEncoder('sha1');
-            $this->passwordHash = $encoder->encodePassword($this->password, $this->getSalt());
-        }
+        $this->passwordHash = $hashPassword;
+        $this->algorithm = $algorithm;
     }
 
     /**


### PR DESCRIPTION
ok, this gets things working again but requires a new config parameter "password_encoder". one day we can hopefully just somehow inject the right MessageDigestPasswordEncoder() instance, but right now i dont see how to determine the instance to set, or does it support fetching the algorithm from the instance so that we can store it with the user.

furthermore right now i do not know if we can make it possible to use DoctrineUserBundle in different providers with different settings. seems like a really tricky issue to handle and probably requires stopping to read the dependencies and parameters from the container service directly.
