### PR TITLE
Removed useless attributes

### DIFF
--- a/Model/User.php
+++ b/Model/User.php
@@ -118,16 +118,6 @@ abstract class User implements AdvancedAccountInterface
      */
     protected $rememberMeToken;
 
-    /**
-     * @var Collection
-     */
-    protected $groups;
-
-    /**
-     * @var Collection
-     */
-    protected $permissions;
-
     public function __construct($algorithm)
     {
         $this->algorithm = $algorithm;


### PR DESCRIPTION
This commit removes the `$groups` and `$permissions` in the `User` class as they are useless in this branch.
