### PR TITLE
Repo url

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,3 @@
-The development has **moved to a [new repository](https://github.com/FriendsOfSymfony/UserBundle)**.
+The development has **moved to a [new repository](https://github.com/FriendsOfSymfony/FOSUserBundle)**.
 
 Please update your submodules.


### PR DESCRIPTION
This updates the url of the FOS repo in the readme for latest changes.

Note that the knplabs repo should probably also be renamed to allow having the right bundle name on symfony2bundles.

Btw, http://www.knplabs.com/fr/contribution/symfony2/user-bundle should probably link to the FOS repo instead of the knplabs one as it is not maintained.
